### PR TITLE
Release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # FANS Changelog
 
+## latest
+
+- Update TIK GitHub links in the documentation to public GitHub links https://github.com/DataAnalyticsEngineering/FANS/pull/13
+
 ## v0.1.1
 
 - Disable sorting of includes in clang-format https://github.com/DataAnalyticsEngineering/FANS/pull/7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # FANS Changelog
 
-## latest
+## v0.1.2
 
 - Update TIK GitHub links in the documentation to public GitHub links https://github.com/DataAnalyticsEngineering/FANS/pull/13
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.0...3.28)
 # ##############################################################################
 
 project(FANS
-        VERSION 0.1.1
+        VERSION 0.1.2
         LANGUAGES C CXX
 )
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Spack is a package manager designed for high-performance computing environments.
 1. Clone the repository:
 
     ```bash
-    git clone https://github.tik.uni-stuttgart.de/DAE/FANS.git
+    git clone https://github.com/DataAnalyticsEngineering/FANS.git
     cd FANS
     ```
 

--- a/cmake/packaging/CMakeLists.txt
+++ b/cmake/packaging/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CPACK_OUTPUT_FILE_PREFIX "${CMAKE_BINARY_DIR}/packages")
 set(CPACK_PACKAGE_NAME "${PROJECT_NAME}")
 set(CPACK_PACKAGE_VENDOR "MIB DAE Stuttgart")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "FANS - Fourier Accelerated Nodal Solver" CACHE STRING "Extended summary.")
-set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.tik.uni-stuttgart.de/DAE/FANS/")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/DataAnalyticsEngineering/FANS")
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "MIB DAE Stuttgart")
 
 set(CPACK_PACKAGE_INSTALL_DIRECTORY ${CPACK_PACKAGE_NAME})

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,7 +14,7 @@ Set up a development container with your current working directory (in there, us
 First, clone FANS:
 
 ```bash
-git clone https://github.tik.uni-stuttgart.de/DAE/FANS.git
+git clone https://github.com/DataAnalyticsEngineering/FANS.git
 cd FANS
 ```
 


### PR DESCRIPTION
This release is necessary to update outdated TIK GitHub links in the documentation: https://github.com/DataAnalyticsEngineering/FANS/pull/13