### PR TITLE
Add support for MacOS with ARM CPUs (CMake + GitHub Action)

### DIFF
--- a/.github/workflows/build_and_test-mac.yaml
+++ b/.github/workflows/build_and_test-mac.yaml
@@ -1,0 +1,71 @@
+name: Build and Test
+# Builds FANS for macOS 14 on M1 CPU and runs the tests.
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{github.event_name == 'pull_request'}}
+
+jobs:
+  build:
+    name: macOS 14 (M1)
+    runs-on: macos-14
+    env:
+      FANS_BUILD_DIR: build
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install FANS dependencies
+        run: brew install cmake hdf5-mpi openmpi eigen fttw
+
+      - name: Generate build directory
+        run: mkdir -p ${{ env.FANS_BUILD_DIR }}
+
+      - name: Configure
+        working-directory: ${{ env.FANS_BUILD_DIR }}
+        run: |
+          cmake --version
+          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: macOS 14 (M1) CMakeCache
+          path: ${{ env.FANS_BUILD_DIR }}/CMakeCache.txt
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: macOS 14 (M1) CMakeLogs
+          path: '${{ env.FANS_BUILD_DIR }}/CMakeFiles/*.log'
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: macOS 14 (M1) CompileCommands
+          path: ${{ env.FANS_BUILD_DIR }}/compile_commands.json
+
+      - name: Compile
+        working-directory: ${{ env.FANS_BUILD_DIR }}
+        run:
+          cmake --build . -j $(nproc) || cmake --build . -j1
+
+      - name: Tests
+        working-directory: ${{ env.FANS_BUILD_DIR }}
+        env:
+          CTEST_OUTPUT_ON_FAILURE: 1
+        run: ctest
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: macOS 14 (M1) CTest logs
+          path: ${{ env.FANS_BUILD_DIR }}/Testing/Temporary/LastTest.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,11 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 # From https://stackoverflow.com/questions/73248130/how-to-avoid-the-removal-of-the-rpath-during-cmake-install-step
 
 # Set RPATH to be relative and honor user overrides, whether at the command line or FetchContent
-set(RPATH_BASE "$ORIGIN")
+if(APPLE)
+        set(RPATH_BASE "@loader_path")
+else()
+        set(RPATH_BASE "$ORIGIN")
+endif()
 file(RELATIVE_PATH REL_PATH_LIB
         "/${CMAKE_INSTALL_BINDIR}/"
         "/${CMAKE_INSTALL_LIBDIR}/")


### PR DESCRIPTION
Add support for macOS.

Changes in `CMakeLists.txt`:
- Apple specific relative RPATH

New GitHub Actions workflow file for building and testing on macOS:
- Using the `macos-14` GitHub hosted runner (M1 CPU)
- No container image, dependencies are installed directly in the workflow
- Brew dependencies
- `clang` C++ compiler (CMake default on macOS)
- Otherwise more less the same workflow file as for Ubuntu