### PR TITLE
Remove unused dependency OpenMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,8 +81,6 @@ find_package(HDF5 REQUIRED COMPONENTS CXX)
 
 find_package(Eigen3 REQUIRED)
 
-find_package(OpenMP REQUIRED)
-
 find_package(MPI REQUIRED)
 
 find_package(FFTW3 REQUIRED COMPONENTS DOUBLE MPI)
@@ -174,8 +172,6 @@ target_link_libraries(FANS_FANS PUBLIC ${FFTW3_LIBRARIES})
 target_compile_definitions(FANS_FANS PUBLIC ${FFTW3_DEFINITIONS})
 
 target_link_libraries(FANS_FANS PUBLIC Eigen3::Eigen)
-
-target_link_libraries(FANS_FANS PUBLIC OpenMP::OpenMP_CXX)
 
 
 target_link_libraries(FANS_main PRIVATE FANS::FANS)

--- a/cmake/FANSConfig.cmake.in
+++ b/cmake/FANSConfig.cmake.in
@@ -18,7 +18,6 @@ if (NOT HDF5_C_IS_PARALLEL)
     message(FATAL_ERROR "Parallel HDF5 implementation (mpi) required but not found!")
 endif()
 find_dependency(Eigen3)
-find_dependency(OpenMP)
 find_dependency(MPI)
 find_dependency(FFTW3 COMPONENTS DOUBLE MPI)
 


### PR DESCRIPTION
While working on #25, I stumbled across the `OpenMP` dependency in the `CMakeLists.txt` file. It was not covered by our listed dependencies when I tried to install them with `brew` on macOS. So I wanted to check if it was even needed, and it actually isn't. Building FANS as well as all test cases succeed without OpenMP. I guess I confused it with openmpi in the first place, since I'm not really familiar with both.

This PR removes `OpenMP` as a dependency in the CMake recipe.