### PR TITLE
The LS1 PR: Introduce system for checking compiler flags: avx2 & fma

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,13 +114,13 @@ elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
         execute_process(COMMAND lscpu OUTPUT_VARIABLE LSCU_OUTPUT ERROR_QUIET)
 
         # Default to AVX; enable AVX2 if supported by hardware
-        set(USE_AVX2 FALSE)
+        set(FANS_USE_AVX2 FALSE)
         if (LSCU_OUTPUT MATCHES "avx2")
-            set(USE_AVX2 TRUE)
+            set(FANS_USE_AVX2 TRUE)
         endif()
 
         # Apply compiler options based on hardware detection
-        if (USE_AVX2)
+        if (FANS_USE_AVX2)
             message(STATUS "AVX2 and FMA supported by hardware; using -mavx2 and -mfma.")
             target_compile_options(FANS_FANS PUBLIC -mavx2 -mfma)
         else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,11 +111,11 @@ elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
         target_compile_options(FANS_FANS PUBLIC -mavx2 -mfma)
     elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
         # Linux: Check for AVX2 support using lscpu
-        execute_process(COMMAND lscpu OUTPUT_VARIABLE LSCU_OUTPUT ERROR_QUIET)
+        execute_process(COMMAND lscpu OUTPUT_VARIABLE LSCPU_OUTPUT ERROR_QUIET)
 
         # Default to AVX; enable AVX2 if supported by hardware
         set(FANS_USE_AVX2 FALSE)
-        if (LSCU_OUTPUT MATCHES "avx2")
+        if (LSCPU_OUTPUT MATCHES "avx2")
             set(FANS_USE_AVX2 TRUE)
         endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,8 +102,42 @@ add_library(FANS::FANS ALIAS FANS_FANS)
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
     target_compile_options(FANS_FANS PUBLIC -march=armv8-a+simd+fp+crypto)
 elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
-    target_compile_options(FANS_FANS PUBLIC -mavx2 -mfma)
-endif ()
+    # Detecting if there is avx2 and fma support on linux
+    # Deteced together, because these flags were introduced by Intel Haskell 4th. Gen
+    # Distinguishing between mac/linux because lscpu is used, which is not supported on mac.
+    if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+        # macOS: Assume AVX2 and FMA are supported as per requirement
+        message(STATUS "Assuming AVX2 and FMA support on macOS; using -mavx2 and -mfma.")
+        target_compile_options(FANS_FANS PUBLIC -mavx2 -mfma)
+    elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        # Linux: Check for AVX2 support using lscpu or /proc/cpuinfo
+        execute_process(
+            COMMAND lscpu
+            OUTPUT_VARIABLE LSCU_OUTPUT
+            ERROR_QUIET
+        )
+
+        # Default to AVX; enable AVX2 if supported by hardware
+        set(USE_AVX2 FALSE)
+        if (LSCU_OUTPUT MATCHES "avx2")
+            set(USE_AVX2 TRUE)
+        endif()
+
+        # Apply compiler options based on hardware detection
+        if (USE_AVX2)
+            message(STATUS "AVX2 and FMA supported by hardware; using -mavx2 and -mfma.")
+            target_compile_options(FANS_FANS PUBLIC -mavx2 -mfma)
+        else()
+            message(WARNING "AVX2 and FMA not supported by hardware; falling back to AVX.")
+            target_compile_options(FANS_FANS PUBLIC -mavx)
+        endif()
+    else()
+        message(WARNING "Unsupported system for AVX2 detection; defaulting to -mavx.")
+        target_compile_options(FANS_FANS PUBLIC -mavx)
+    endif()
+endif()
+
+
 
 add_executable(FANS_main)
 add_custom_command(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,12 +110,8 @@ elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
         message(STATUS "Assuming AVX2 and FMA support on macOS; using -mavx2 and -mfma.")
         target_compile_options(FANS_FANS PUBLIC -mavx2 -mfma)
     elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-        # Linux: Check for AVX2 support using lscpu or /proc/cpuinfo
-        execute_process(
-            COMMAND lscpu
-            OUTPUT_VARIABLE LSCU_OUTPUT
-            ERROR_QUIET
-        )
+        # Linux: Check for AVX2 support using lscpu
+        execute_process(COMMAND lscpu OUTPUT_VARIABLE LSCU_OUTPUT ERROR_QUIET)
 
         # Default to AVX; enable AVX2 if supported by hardware
         set(USE_AVX2 FALSE)
@@ -136,8 +132,6 @@ elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
         target_compile_options(FANS_FANS PUBLIC -mavx)
     endif()
 endif()
-
-
 
 add_executable(FANS_main)
 add_custom_command(


### PR DESCRIPTION
+ i7-2600 was otherwise not able to built
+ super backward change
+ does not apply/test on macos