### PR TITLE
Fix spack installation tutorial in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ Spack is a package manager designed for high-performance computing environments.
 
     ```bash
     git clone https://github.com/spack/spack.git
-    cd spack/bin
-    source ./spack
+    cd spack
+    source ./share/spack/setup-env.csh
     ```
 
 2. **Install Dependencies**: Once Spack is set up, you can install the required dependencies:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Spack is a package manager designed for high-performance computing environments.
     ```bash
     git clone https://github.com/spack/spack.git
     cd spack
-    source ./share/spack/setup-env.csh
+    . ./share/spack/setup-env.sh
     ```
 
 2. **Install Dependencies**: Once Spack is set up, you can install the required dependencies:


### PR DESCRIPTION
In the current version, the command to activate the spack environment is not working.
This changes the command to the one provided in https://spack.readthedocs.io/en/latest/getting_started.html#shell-support