### PR TITLE
modified way to provide microstructure input in json

### DIFF
--- a/include/reader.h
+++ b/include/reader.h
@@ -18,6 +18,7 @@ class Reader {
     json                           materialProperties;
     double                         TOL;
     json                           errorParameters;
+    json                           microstructure;
     int                            n_it;
     vector<vector<vector<double>>> g0;
     string                         problemType;

--- a/include/solver.h
+++ b/include/solver.h
@@ -464,7 +464,7 @@ void Solver<howmany>::postprocess(Reader reader, const char resultsFileName[], i
     }
 
     // Concatenate reader.ms_datasetname and reader.results_prefix into reader.ms_datasetname
-    strcat(reader.ms_datasetname, "/");
+    strcat(reader.ms_datasetname, "_results/");
     strcat(reader.ms_datasetname, reader.results_prefix);
 
     // Write results to results h5 file

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -60,16 +60,16 @@ void Reader ::ReadInputFile(char fn[])
         json     j;
         i >> j;
 
-        strcpy(ms_filename, j["ms_filename"].get<string>().c_str());
-        strcpy(ms_datasetname, j["ms_datasetname"].get<string>().c_str());
+        microstructure = j["microstructure"];
+        strcpy(ms_filename, microstructure["filepath"].get<string>().c_str());
+        strcpy(ms_datasetname, microstructure["datasetname"].get<string>().c_str());
+        L = microstructure["L"].get<vector<double>>();
 
         if (j.contains("results_prefix")) {
             strcpy(results_prefix, j["results_prefix"].get<string>().c_str());
         } else {
             strcpy(results_prefix, "");
         }
-
-        L = j["ms_L"].get<vector<double>>();
 
         errorParameters = j["error_parameters"];
         TOL             = errorParameters["tolerance"].get<double>();

--- a/test/input_files/test_J2Plasticity.json
+++ b/test/input_files/test_J2Plasticity.json
@@ -1,7 +1,9 @@
 {
-    "ms_filename": "microstructures/sphere32.h5",
-    "ms_datasetname": "/sphere/32x32x32/ms",
-    "ms_L": [1.0, 1.0, 1.0],
+    "microstructure": {
+        "filepath": "microstructures/sphere32.h5",
+        "datasetname": "/sphere/32x32x32/ms",
+        "L": [1.0, 1.0, 1.0]
+    },
 
     "problem_type": "mechanical",
     "matmodel": "J2ViscoPlastic_NonLinearIsotropicHardening",

--- a/test/input_files/test_LinearElastic.json
+++ b/test/input_files/test_LinearElastic.json
@@ -1,7 +1,9 @@
 {
-    "ms_filename": "microstructures/sphere32.h5",
-    "ms_datasetname": "/sphere/32x32x32/ms",
-    "ms_L": [1.0, 1.0, 1.0],
+    "microstructure": {
+        "filepath": "microstructures/sphere32.h5",
+        "datasetname": "/sphere/32x32x32/ms",
+        "L": [1.0, 1.0, 1.0]
+    },
 
     "problem_type": "mechanical",
     "matmodel": "LinearElasticIsotropic",

--- a/test/input_files/test_LinearThermal.json
+++ b/test/input_files/test_LinearThermal.json
@@ -1,7 +1,9 @@
 {
-    "ms_filename": "microstructures/sphere32.h5",
-    "ms_datasetname": "/sphere/32x32x32/ms",
-    "ms_L": [1.0, 1.0, 1.0],
+    "microstructure": {
+        "filepath": "microstructures/sphere32.h5",
+        "datasetname": "/sphere/32x32x32/ms",
+        "L": [1.0, 1.0, 1.0]
+    },
 
     "problem_type": "thermal",
     "matmodel": "LinearThermalIsotropic",

--- a/test/input_files/test_PseudoPlastic.json
+++ b/test/input_files/test_PseudoPlastic.json
@@ -1,7 +1,9 @@
 {
-    "ms_filename": "microstructures/sphere32.h5",
-    "ms_datasetname": "/sphere/32x32x32/ms",
-    "ms_L": [1.0, 1.0, 1.0],
+    "microstructure": {
+        "filepath": "microstructures/sphere32.h5",
+        "datasetname": "/sphere/32x32x32/ms",
+        "L": [1.0, 1.0, 1.0]
+    },
 
     "problem_type": "mechanical",
     "matmodel": "PseudoPlasticNonLinearHardening",

--- a/test/test_pyfans/input.json
+++ b/test/test_pyfans/input.json
@@ -1,6 +1,6 @@
 {
     "microstructure": {
-        "filepath": "microstructures/sphere32.h5",
+        "filepath": "../microstructures/sphere32.h5",
         "datasetname": "/sphere/32x32x32/ms",
         "L": [1.0, 1.0, 1.0]
     },

--- a/test/test_pyfans/input.json
+++ b/test/test_pyfans/input.json
@@ -1,7 +1,9 @@
 {
-    "ms_filename": "../microstructures/sphere32.h5",
-    "ms_datasetname": "/sphere/32x32x32/ms",
-    "ms_L": [1.0, 1.0, 1.0],
+    "microstructure": {
+        "filepath": "microstructures/sphere32.h5",
+        "datasetname": "/sphere/32x32x32/ms",
+        "L": [1.0, 1.0, 1.0]
+    },
 
     "problem_type": "mechanical",
     "matmodel": "LinearElasticIsotropic",


### PR DESCRIPTION
Solves #40 and #41.

Previously:
```
"ms_filename": "microstructures/sphere32.h5",
"ms_datasetname": "/sphere/32x32x32/ms",
"ms_L": [1.0, 1.0, 1.0],
```

Now: 
```
"microstructure": {
        "filepath": "microstructures/sphere32.h5",
        "datasetname": "/sphere/32x32x32/ms",
        "L": [1.0, 1.0, 1.0]
 },
```


Previously, results would be written to h5 file in the group `/datasetname/....`, now it will be written to `/datasetname_results/....` 