### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+<!-- Add a short description of your contribution here. Skip this if the title is self-explanatory -->
+
+Checklist:
+
+- [ ] I made sure that the CI passed before I ask for a review.
+- [ ] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
+- [ ] If necessary, I made changes to the documentation and/or added new content.
+- [ ] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.


### PR DESCRIPTION
This PR adds a [pull request template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository). The main reason is to remind the contributor that every PR must have a changelog entry, must pass the CI, and all commits must be squashed.