### PR TITLE
Compiling on conda-forge's Macs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0...3.28)
+cmake_minimum_required(VERSION 3.21)
 
 # ##############################################################################
 # GENERAL SETTINGS
@@ -17,7 +17,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 # with -fno-implicit-templates I get linker errors when using std:: stuff
 # TODO: should be developer specific, by using e.g. CMake Presets
-set(CMAKE_CXX_FLAGS "-fmax-errors=1 -O3")
+# moved flags to CMakePresets.json to support multiple compilers cleanly
 set(CMAKE_PREFIX_PATH $ENV{CMAKE_PREFIX_PATH})
 
 # IPO
@@ -56,11 +56,7 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 # From https://stackoverflow.com/questions/73248130/how-to-avoid-the-removal-of-the-rpath-during-cmake-install-step
 
 # Set RPATH to be relative and honor user overrides, whether at the command line or FetchContent
-if(APPLE)
-        set(RPATH_BASE "@loader_path")
-else()
-        set(RPATH_BASE "$ORIGIN")
-endif()
+set(RPATH_BASE "$ORIGIN")
 file(RELATIVE_PATH REL_PATH_LIB
         "/${CMAKE_INSTALL_BINDIR}/"
         "/${CMAKE_INSTALL_LIBDIR}/")
@@ -84,6 +80,8 @@ set(HDF5_ENABLE_PARALLEL ON)
 find_package(HDF5 REQUIRED COMPONENTS CXX)
 
 find_package(Eigen3 REQUIRED)
+
+find_package(OpenMP REQUIRED)
 
 find_package(MPI REQUIRED)
 
@@ -113,38 +111,10 @@ endif ()
 add_library(FANS::FANS ALIAS FANS_FANS)
 
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
-
+    target_compile_options(FANS_FANS PUBLIC -march=armv8-a+simd+fp+crypto)
 elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
-    # Detecting if there is avx2 and fma support on linux
-    # Deteced together, because these flags were introduced by Intel Haskell 4th. Gen
-    # Distinguishing between mac/linux because lscpu is used, which is not supported on mac.
-    if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-        # macOS: Assume AVX2 and FMA are supported as per requirement
-        message(STATUS "Assuming AVX2 and FMA support on macOS; using -mavx2 and -mfma.")
-        target_compile_options(FANS_FANS PUBLIC -mavx2 -mfma)
-    elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-        # Linux: Check for AVX2 support using lscpu
-        execute_process(COMMAND lscpu OUTPUT_VARIABLE LSCPU_OUTPUT ERROR_QUIET)
-
-        # Default to AVX; enable AVX2 if supported by hardware
-        set(FANS_USE_AVX2 FALSE)
-        if (LSCPU_OUTPUT MATCHES "avx2")
-            set(FANS_USE_AVX2 TRUE)
-        endif()
-
-        # Apply compiler options based on hardware detection
-        if (FANS_USE_AVX2)
-            message(STATUS "AVX2 and FMA supported by hardware; using -mavx2 and -mfma.")
-            target_compile_options(FANS_FANS PUBLIC -mavx2 -mfma)
-        else()
-            message(WARNING "AVX2 and FMA not supported by hardware; falling back to AVX.")
-            target_compile_options(FANS_FANS PUBLIC -mavx)
-        endif()
-    else()
-        message(WARNING "Unsupported system for AVX2 detection; defaulting to -mavx.")
-        target_compile_options(FANS_FANS PUBLIC -mavx)
-    endif()
-endif()
+    target_compile_options(FANS_FANS PUBLIC -mavx2 -mfma)
+endif ()
 
 add_executable(FANS_main)
 add_custom_command(
@@ -228,6 +198,9 @@ target_link_libraries(FANS_FANS PUBLIC ${FFTW3_LIBRARIES})
 target_compile_definitions(FANS_FANS PUBLIC ${FFTW3_DEFINITIONS})
 
 target_link_libraries(FANS_FANS PUBLIC Eigen3::Eigen)
+
+target_link_libraries(FANS_FANS PUBLIC OpenMP::OpenMP_CXX)
+
 
 target_link_libraries(FANS_main PRIVATE FANS::FANS)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 # with -fno-implicit-templates I get linker errors when using std:: stuff
 # TODO: should be developer specific, by using e.g. CMake Presets
-# moved flags to CMakePresets.json to support multiple compilers cleanly
 set(CMAKE_PREFIX_PATH $ENV{CMAKE_PREFIX_PATH})
 
 # IPO
@@ -54,9 +53,12 @@ set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 # From https://stackoverflow.com/questions/73248130/how-to-avoid-the-removal-of-the-rpath-during-cmake-install-step
-
 # Set RPATH to be relative and honor user overrides, whether at the command line or FetchContent
-set(RPATH_BASE "$ORIGIN")
+if(APPLE)
+        set(RPATH_BASE "@loader_path")
+else()
+        set(RPATH_BASE "$ORIGIN")
+endif()
 file(RELATIVE_PATH REL_PATH_LIB
         "/${CMAKE_INSTALL_BINDIR}/"
         "/${CMAKE_INSTALL_LIBDIR}/")
@@ -108,11 +110,11 @@ else ()
 endif ()
 add_library(FANS::FANS ALIAS FANS_FANS)
 
-# if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
-#     target_compile_options(FANS_FANS PUBLIC -march=armv8-a+simd+fp+crypto)
-# elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
-#     target_compile_options(FANS_FANS PUBLIC -mavx2 -mfma)
-# endif ()
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
+    target_compile_options(FANS_FANS PUBLIC -march=armv8-a+simd+fp+crypto)
+elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+    target_compile_options(FANS_FANS PUBLIC -mavx2 -mfma)
+endif ()
 
 add_executable(FANS_main)
 add_custom_command(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,11 +108,11 @@ else ()
 endif ()
 add_library(FANS::FANS ALIAS FANS_FANS)
 
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
-    target_compile_options(FANS_FANS PUBLIC -march=armv8-a+simd+fp+crypto)
-elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
-    target_compile_options(FANS_FANS PUBLIC -mavx2 -mfma)
-endif ()
+# if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
+#     target_compile_options(FANS_FANS PUBLIC -march=armv8-a+simd+fp+crypto)
+# elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+#     target_compile_options(FANS_FANS PUBLIC -mavx2 -mfma)
+# endif ()
 
 add_executable(FANS_main)
 add_custom_command(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,8 +81,6 @@ find_package(HDF5 REQUIRED COMPONENTS CXX)
 
 find_package(Eigen3 REQUIRED)
 
-find_package(OpenMP REQUIRED)
-
 find_package(MPI REQUIRED)
 
 find_package(FFTW3 REQUIRED COMPONENTS DOUBLE MPI)
@@ -198,9 +196,6 @@ target_link_libraries(FANS_FANS PUBLIC ${FFTW3_LIBRARIES})
 target_compile_definitions(FANS_FANS PUBLIC ${FFTW3_DEFINITIONS})
 
 target_link_libraries(FANS_FANS PUBLIC Eigen3::Eigen)
-
-target_link_libraries(FANS_FANS PUBLIC OpenMP::OpenMP_CXX)
-
 
 target_link_libraries(FANS_main PRIVATE FANS::FANS)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,8 +14,6 @@
       "binaryDir": "${sourceDir}/build/gcc-release",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_C_COMPILER": "/usr/bin/gcc",
-        "CMAKE_CXX_COMPILER": "/usr/bin/g++",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       }
     },
@@ -27,8 +25,6 @@
       "binaryDir": "${sourceDir}/build/gcc-debug",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_C_COMPILER": "/usr/bin/gcc",
-        "CMAKE_CXX_COMPILER": "/usr/bin/g++",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       }
     },
@@ -40,8 +36,6 @@
       "binaryDir": "${sourceDir}/build/clang-release-linux",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_C_COMPILER": "/usr/bin/clang",
-        "CMAKE_CXX_COMPILER": "/usr/bin/clang++",
         "CMAKE_CXX_FLAGS": "-stdlib=libstdc++",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       }
@@ -54,8 +48,6 @@
       "binaryDir": "${sourceDir}/build/clang-debug-linux",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_C_COMPILER": "/usr/bin/clang",
-        "CMAKE_CXX_COMPILER": "/usr/bin/clang++",
         "CMAKE_CXX_FLAGS": "-stdlib=libstdc++",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,10 +1,5 @@
 {
   "version": 6,
-  "cmakeMinimumRequired": {
-    "major": 3,
-    "minor": 23,
-    "patch": 0
-  },
   "configurePresets": [
     {
       "name": "gcc-release",
@@ -14,6 +9,7 @@
       "binaryDir": "${sourceDir}/build/gcc-release",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_CXX_FLAGS": "-fmax-errors=1 -O3",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       }
     },
@@ -25,6 +21,7 @@
       "binaryDir": "${sourceDir}/build/gcc-debug",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_CXX_FLAGS": "-fmax-errors=1 -O3",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       }
     },
@@ -36,7 +33,7 @@
       "binaryDir": "${sourceDir}/build/clang-release-linux",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_CXX_FLAGS": "-stdlib=libstdc++",
+        "CMAKE_CXX_FLAGS": "-stdlib=libstdc++ -O3",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       }
     },
@@ -48,7 +45,7 @@
       "binaryDir": "${sourceDir}/build/clang-debug-linux",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_CXX_FLAGS": "-stdlib=libstdc++",
+        "CMAKE_CXX_FLAGS": "-stdlib=libstdc++ -O3",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       }
     },
@@ -61,6 +58,11 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
       }
     },
     {
@@ -72,6 +74,11 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
       }
     }
   ],

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -68,8 +68,6 @@
       "binaryDir": "${sourceDir}/build/clang-release-macos",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_C_COMPILER": "/usr/bin/clang",
-        "CMAKE_CXX_COMPILER": "/usr/bin/clang++",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       }
     },
@@ -81,8 +79,6 @@
       "binaryDir": "${sourceDir}/build/clang-debug-macos",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_C_COMPILER": "/usr/bin/clang",
-        "CMAKE_CXX_COMPILER": "/usr/bin/clang++",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       }
     }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,116 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 23,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "gcc-release",
+      "displayName": "GCC Release (Linux)",
+      "description": "GCC compiler with Release build type",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build/gcc-release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_C_COMPILER": "/usr/bin/gcc",
+        "CMAKE_CXX_COMPILER": "/usr/bin/g++",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    },
+    {
+      "name": "gcc-debug",
+      "displayName": "GCC Debug (Linux)",
+      "description": "GCC compiler with Debug build type",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build/gcc-debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_C_COMPILER": "/usr/bin/gcc",
+        "CMAKE_CXX_COMPILER": "/usr/bin/g++",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    },
+    {
+      "name": "clang-release-linux",
+      "displayName": "Clang Release (Linux)",
+      "description": "Clang on Linux using libstdc++ for Release",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build/clang-release-linux",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_C_COMPILER": "/usr/bin/clang",
+        "CMAKE_CXX_COMPILER": "/usr/bin/clang++",
+        "CMAKE_CXX_FLAGS": "-stdlib=libstdc++",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    },
+    {
+      "name": "clang-debug-linux",
+      "displayName": "Clang Debug (Linux)",
+      "description": "Clang on Linux using libstdc++ for Debug",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build/clang-debug-linux",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_C_COMPILER": "/usr/bin/clang",
+        "CMAKE_CXX_COMPILER": "/usr/bin/clang++",
+        "CMAKE_CXX_FLAGS": "-stdlib=libstdc++",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    },
+    {
+      "name": "clang-release-macos",
+      "displayName": "Clang Release (macOS)",
+      "description": "macOS system Clang using libc++ for Release",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build/clang-release-macos",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_C_COMPILER": "/usr/bin/clang",
+        "CMAKE_CXX_COMPILER": "/usr/bin/clang++",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    },
+    {
+      "name": "clang-debug-macos",
+      "displayName": "Clang Debug (macOS)",
+      "description": "macOS system Clang using libc++ for Debug",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build/clang-debug-macos",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_C_COMPILER": "/usr/bin/clang",
+        "CMAKE_CXX_COMPILER": "/usr/bin/clang++",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "gcc-release",
+      "configurePreset": "gcc-release"
+    },
+    {
+      "name": "gcc-debug",
+      "configurePreset": "gcc-debug"
+    },
+    {
+      "name": "clang-release-linux",
+      "configurePreset": "clang-release-linux"
+    },
+    {
+      "name": "clang-debug-linux",
+      "configurePreset": "clang-debug-linux"
+    },
+    {
+      "name": "clang-release-macos",
+      "configurePreset": "clang-release-macos"
+    },
+    {
+      "name": "clang-debug-macos",
+      "configurePreset": "clang-debug-macos"
+    }
+  ]
+}

--- a/compiling_new.md
+++ b/compiling_new.md
@@ -1,0 +1,144 @@
+# 🔧 Compilation and Build Guide for FANS
+
+This document outlines how to configure, build, and maintain reproducible builds of the **FANS** project using modern CMake presets, with support for multiple compilers and platforms.
+
+---
+
+## 🚀 Prerequisites
+
+- **CMake ≥ 3.23** is required to support `CMakePresets.json` (version 6 or higher).
+- Ensure a working C++ compiler is installed:
+  - GCC (Linux)
+  - Clang (Linux/macOS)
+- CMake >= 3.23 can be installed from a package manager like `apt`, `brew`, or directly from [cmake.org](https://cmake.org/download/).
+
+---
+
+## ⚙️ Preset-Based Build System
+
+CMake presets are defined in `CMakePresets.json` and allow standardized builds across configurations and platforms.
+
+### ✅ Available Configure Presets
+
+| Preset Name              | Compiler       | Platform | C++ Stdlib   | Notes                                                  |
+|--------------------------|----------------|----------|--------------|--------------------------------------------------------|
+| `gcc-release`            | GCC            | Linux    | `libstdc++`  | Standard Linux GCC release build                      |
+| `gcc-debug`              | GCC            | Linux    | `libstdc++`  | Debug variant                                          |
+| `clang-release-linux`    | Clang          | Linux    | `libstdc++`  | Requires GCC installed for `libstdc++` linking        |
+| `clang-debug-linux`      | Clang          | Linux    | `libstdc++`  | Requires `libstdc++-dev` and `libomp` via `apt`       |
+| `clang-release-macos`    | Clang (Apple)  | macOS    | `libc++`     | Uses macOS system Clang and default libc++            |
+| `clang-debug-macos`      | Clang (Apple)  | macOS    | `libc++`     | Same as above with Debug mode                         |
+
+### 🔨 Available Build Presets
+
+| Preset Name              | Description                         |
+|--------------------------|-------------------------------------|
+| `build-gcc-release`      | Build using `gcc-release` preset    |
+| `build-gcc-debug`        | Build using `gcc-debug` preset      |
+| `build-clang-release-linux` | Build with Linux Clang release  |
+| `build-clang-debug-linux`   | Build with Linux Clang debug    |
+| `build-clang-release-macos` | Build with macOS Clang release  |
+| `build-clang-debug-macos`   | Build with macOS Clang debug    |
+
+---
+
+## 🏗️ Building the Project
+
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/DataAnalyticsEngineering/FANS.git
+cd FANS
+```
+
+### 2. Configure using CMake presets
+
+To configure the build system, choose the appropriate preset for your platform and toolchain.
+
+#### Example: GCC Release (Linux)
+
+```bash
+cmake --preset gcc-release
+```
+
+#### Example: GCC Debug (Linux)
+
+```bash
+cmake --preset gcc-debug
+```
+
+#### Example: Clang Release (Linux)
+
+```bash
+cmake --preset clang-release-linux
+```
+
+#### Example: Clang Debug (Linux)
+
+```bash
+cmake --preset clang-debug-linux
+```
+
+#### Example: Clang Release (macOS)
+
+```bash
+cmake --preset clang-release-macos
+```
+
+#### Example: Clang Debug (macOS)
+
+```bash
+cmake --preset clang-debug-macos
+```
+
+---
+
+### 3. Build the Project
+
+Use the following command to build the project after configuration:
+
+```bash
+cmake --build --preset <preset>
+```
+
+For example, if you used the `gcc-release` preset:
+
+```bash
+cmake --build --preset gcc-release
+```
+
+---
+
+### Notes on Clang + libstdc++ (Linux)
+
+If you're using Clang on Linux, and linking against `libstdc++`, you may run into issues where the linker cannot find `-lstdc++`. This is due to missing development libraries that Clang depends on for C++ standard support.
+To make clang find those, there is a special `"CMAKE_CXX_FLAGS": "-stdlib=libstdc++"` in the CMAKE-Preset.
+
+Ensure you have installed the required GCC development libraries:
+
+```bash
+sudo apt install g++ libstdc++-<version>-dev
+```
+
+Where `<version>` should match your system's default GCC version. You can discover available versions via:
+
+```bash
+apt search libstdc++
+```
+
+Additionally, if you are using Clang with OpenMP features, make sure to install:
+
+```bash
+sudo apt install libomp-dev
+```
+
+---
+
+### Platform Distinctions in Presets
+
+Because Clang on Linux often requires explicit linking to `libstdc++`, the presets distinguish between:
+
+- `clang-release-linux`, `clang-debug-linux` – for Linux builds using Clang with system-wide libstdc++.
+- `clang-release-macos`, `clang-debug-macos` – for macOS builds using Clang with system libc++.
+
+This allows for reproducible builds on multiple platforms with appropriate linking and standard library settings.

--- a/compiling_new.md
+++ b/compiling_new.md
@@ -126,12 +126,6 @@ Where `<version>` should match your system's default GCC version. You can discov
 apt search libstdc++
 ```
 
-Additionally, if you are using Clang with OpenMP features, make sure to install:
-
-```bash
-sudo apt install libomp-dev
-```
-
 ---
 
 ### Platform Distinctions in Presets

--- a/include/matmodel.h
+++ b/include/matmodel.h
@@ -43,6 +43,8 @@ class Matmodel {
 
     vector<double> macroscale_loading;
 
+    virtual ~Matmodel() = default;
+
   protected:
     double l_e_x;
     double l_e_y;

--- a/include/solver.h
+++ b/include/solver.h
@@ -9,6 +9,7 @@ template <int howmany>
 class Solver {
   public:
     Solver(Reader reader, Matmodel<howmany> *matmodel);
+    virtual ~Solver() = default;
 
     Reader reader;
 


### PR DESCRIPTION
This PR is part of our effort to introduce `osx` versions of `FANS` via `conda-forge`.
The recipe-update was done in this [PR](https://github.com/conda-forge/fans-feedstock/pull/4)

Restrictive to this process was the fact that conda-forge only builds against Clang on MacOS, and crosscompiles for arm64.
I did this with little to no deep knowledge of CMake and compilation in general - sorry if I messed up any working aspect and introduced some regression. Would be open to fix this obviously.

The overall strategy was:

1. introduce support for Clang using CMakePresets
2. get Clang compilation on conda-forge working for `x86`
3. enable cross-compilation to `arm64`.
4. Get this PR merged into a version
5. From the above version on, conda-forge can build `osx-64` and `osx-arm64` version of `FANS`.

Steps 2 and 3 were mainly carried out in the conda recipe itself. The result of the first step is this PR.
Step 4 and 5 are still ahead of us.


## Introduced Changes

- raise CMake min Verison to `3.21` for Presets
- Introduce presets for gcc and clang, both with release and debug flags (don't know wether helpful/used)
- Ported settings from CMakeLists.txt to Presets
    - there should be no setting missing because of this PR
- ⚠️ CodeChange: added default virtual destructors for `Matmodel` and `Solver`, as those crashed on `osx` as `Illegal Instruction` and also showed up as a compiler warning:
    ```
    /home/USADR/xxxx/scratch/Code/FANS/src/main.cpp:32:9: warning: delete called on 'Matmodel<1>' that is abstract but has non-virtual destructor [-Wdelete-abstract-non-virtual-dtor]
       32 |         delete matmodel;
          |         ^
    ```
- removed all `AVX2` and `FMA` detection logic - those CPUs are just to old.

## Todos

I don't know how these changes will interact with all other setup in the repo itself:
   - Testing
   - Deployment
so please check. Would love PRs on the branch, so I can test the conda-CI.
There is also a Markdown-File which I generated to give a short introduction into how to use the Presets. I would delete that before merging, but maybe it serves a purpose right now as inspo for docs, README and testing...

