### PR TITLE
Pin micro-manager-precice version to 0.8.0 due to pyFANS API incompatibility

### DIFF
--- a/.github/workflows/test_pyfans.yaml
+++ b/.github/workflows/test_pyfans.yaml
@@ -41,7 +41,7 @@ jobs:
       run: |
         python3 -m venv .venv
         . .venv/bin/activate
-        pip install micro-manager-precice
+        pip install micro-manager-precice==0.8.0
 
     - name: Configure
       working-directory: ${{ env.FANS_BUILD_DIR }}


### PR DESCRIPTION
Checklist:

- [ ] I made sure that the CI passed before I ask for a review.
- [ ] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [ ] If necessary, I made changes to the documentation and/or added new content.
- [ ] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
