### PR TITLE
Fix Mem-leak and CMake issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # FANS Changelog
 
+## latest
+
+- Bugfix: mem-leak while reading microstructure and added wider CMake support [#140](https://github.com/DataAnalyticsEngineering/FANS/pull/140)
+
 ## v0.6.2
 
 - Fix bug demanding a leading slash in the datasetname and exiting ungracefully [#123](https://github.com/DataAnalyticsEngineering/FANS/pull/123)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,7 +216,7 @@ target_compile_definitions(FANS_FANS PUBLIC ${FFTW3_DEFINITIONS})
 target_link_libraries(FANS_FANS PUBLIC Eigen3::Eigen)
 target_link_libraries(FANS_FANS PUBLIC nlohmann_json::nlohmann_json)
 
-target_include_directories(FANS_main PRIVATE ${HDF5_INCLUDE_DIRS})
+target_include_directories(FANS_main PRIVATE ${HDF5_INCLUDE_DIRS} ${FFTW3_INCLUDE_DIRS})
 target_link_libraries(FANS_main PRIVATE FANS::FANS)
 
 # ##############################################################################

--- a/cmake/modules/FindFFTW3.cmake
+++ b/cmake/modules/FindFFTW3.cmake
@@ -72,11 +72,15 @@ macro(find_specific_libraries KIND PARALLEL)
     # adding target properties to the different cases
     ##   MPI
     if(PARALLEL STREQUAL "MPI")
-      if(MPI_C_LIBRARIES)
-        set_target_properties(fftw3::${kind}::mpi PROPERTIES
-          IMPORTED_LOCATION "${FFTW3_${KIND}_${PARALLEL}_LIBRARY}"
-          INTERFACE_INCLUDE_DIRECTORIES "${FFTW3_INCLUDE_DIR_PARALLEL}"
-          IMPORTED_LINK_INTERFACE_LIBRARIES ${MPI_C_LIBRARIES})
+      set_target_properties(fftw3::${kind}::mpi PROPERTIES
+        IMPORTED_LOCATION "${FFTW3_${KIND}_${PARALLEL}_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${FFTW3_INCLUDE_DIR_PARALLEL}"
+      )
+
+      if(MPI_C_LIBRARIES AND NOT MPI_C_LIBRARIES STREQUAL "")
+        set_property(TARGET fftw3::${kind}::mpi PROPERTY
+          INTERFACE_LINK_LIBRARIES "${MPI_C_LIBRARIES}"
+        )
       endif()
     endif()
     ##   OpenMP

--- a/pixi.lock
+++ b/pixi.lock
@@ -1592,7 +1592,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-abi-5.0.1.80-hf414acd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/fftw-3.3.10-mpi_openmpi_h76e6d66_12.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fftw-3.3.11-mpi_openmpi_h76e6d66_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-12.1.0-hff5e90c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
@@ -2000,7 +2000,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigen-abi-5.0.1.100-h9a8c16c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fftw-3.3.10-mpi_openmpi_h79548e3_12.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fftw-3.3.11-mpi_openmpi_h79548e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fmt-12.1.0-h20c602a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
@@ -2407,7 +2407,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/eigen-abi-5.0.1.80-h969a130_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/fftw-3.3.10-mpi_openmpi_h63b4274_12.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fftw-3.3.11-mpi_openmpi_h63b4274_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-12.1.0-hda137b5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
@@ -2768,7 +2768,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/eigen-abi-5.0.1.100-h485a483_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fftw-3.3.10-mpi_openmpi_h83537c7_12.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fftw-3.3.11-mpi_openmpi_h83537c7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-12.1.0-h403dcb5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
@@ -6402,7 +6402,7 @@ packages:
   depends:
   - libcxx >=22
   - hdf5 >=1.14.6,<1.14.7.0a0 mpi_openmpi_*
-  - fftw >=3.3.10,<4.0a0
+  - fftw >=3.3.11,<4.0a0
   - fftw * mpi_openmpi_*
 - conda: .
   name: fans
@@ -6416,7 +6416,7 @@ packages:
   - libstdcxx >=15
   - libgcc >=15
   - hdf5 >=1.14.6,<1.14.7.0a0 mpi_openmpi_*
-  - fftw >=3.3.10,<4.0a0
+  - fftw >=3.3.11,<4.0a0
   - fftw * mpi_openmpi_*
 - conda: .
   name: fans
@@ -6429,7 +6429,7 @@ packages:
   depends:
   - libcxx >=22
   - hdf5 >=1.14.6,<1.14.7.0a0 mpi_openmpi_*
-  - fftw >=3.3.10,<4.0a0
+  - fftw >=3.3.11,<4.0a0
   - fftw * mpi_openmpi_*
 - conda: .
   name: fans
@@ -6442,7 +6442,7 @@ packages:
   - libstdcxx >=15
   - libgcc >=15
   - hdf5 >=1.14.6,<1.14.7.0a0 mpi_openmpi_*
-  - fftw >=3.3.10,<4.0a0
+  - fftw >=3.3.11,<4.0a0
   - fftw * mpi_openmpi_*
 - conda: https://conda.anaconda.org/conda-forge/linux-64/fftw-3.3.10-mpi_openmpi_h76e6d66_12.conda
   sha256: 66b0fe5b5e52565ee7120f5e897b1d206494c0440b7c00d4ec0ae09549e1cedc
@@ -6471,6 +6471,20 @@ packages:
   license_family: GPL
   size: 1925113
   timestamp: 1771754008607
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fftw-3.3.11-mpi_openmpi_h76e6d66_0.conda
+  sha256: 0949915580511f07e46d5509d8d16e7ae52910c426aa026dfba51cd188f0d93f
+  md5: 1f27b20b2c508b341d2f2fffc038318b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - libstdcxx >=14
+  - openmpi >=5.0.10,<6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 2243005
+  timestamp: 1776781947588
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fftw-3.3.10-mpi_openmpi_h79548e3_12.conda
   sha256: da93aca35dfc28cadf02d952c2e2edbbc82e13e6503058f525eda3d92f41cd3f
   md5: 862a16425e14f102cf30818160328013
@@ -6496,6 +6510,19 @@ packages:
   license_family: GPL
   size: 1446023
   timestamp: 1771753652128
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fftw-3.3.11-mpi_openmpi_h79548e3_0.conda
+  sha256: b209929f5c33756a3c84f8ef43507749b85be09ee0b3b975b5e0c2f3484e3e66
+  md5: db9e364f3a2395debbbb5dbbdd6c7313
+  depends:
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - libstdcxx >=14
+  - openmpi >=5.0.10,<6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 1765261
+  timestamp: 1776782018274
 - conda: https://conda.anaconda.org/conda-forge/osx-64/fftw-3.3.10-mpi_openmpi_h63b4274_12.conda
   sha256: e5dbf27576c5773034560395e37220b95b4b279ed037da2a9af7d36981cfbedf
   md5: 6e7cd3e40705a769a1e1af286b668f70
@@ -6523,6 +6550,20 @@ packages:
   license_family: GPL
   size: 1807039
   timestamp: 1771754664178
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fftw-3.3.11-mpi_openmpi_h63b4274_0.conda
+  sha256: be9d79fe2fa453c6ce0b83a5b2c809c7e9a3bdf6af4b5a984b72add962331bca
+  md5: cd9442c07a68a171acc0c3eec57b0b85
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - llvm-openmp >=19.1.7
+  - openmpi >=5.0.10,<6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 1861341
+  timestamp: 1776783990081
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fftw-3.3.10-mpi_openmpi_h83537c7_12.conda
   sha256: aff483eea254aa370c76eec87dd19f981c791a0824dec9c2f0e01881d95e3d5e
   md5: 96b7104aadf94ad19b5592655da364ce
@@ -6550,6 +6591,20 @@ packages:
   license_family: GPL
   size: 757377
   timestamp: 1771753896425
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fftw-3.3.11-mpi_openmpi_h83537c7_0.conda
+  sha256: 31353fa1ad22a539b788347687e9a93e40bb44c8653733edfe0de310d6fabced
+  md5: 3ce1481c6d215e40ade8e91265a37d54
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - llvm-openmp >=19.1.7
+  - openmpi >=5.0.10,<6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 782914
+  timestamp: 1776782206460
 - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
   sha256: 6b471a18372bbd52bdf32fc965f71de3bc1b5219418b8e6b3875a67a7b08c483
   md5: 8fa8358d022a3a9bd101384a808044c6

--- a/pyfans/CMakeLists.txt
+++ b/pyfans/CMakeLists.txt
@@ -1,5 +1,5 @@
 pybind11_add_module(PyFANS micro.hpp micro.cpp)
-target_include_directories(PyFANS PRIVATE ${HDF5_INCLUDE_DIRS})
+target_include_directories(PyFANS PRIVATE ${HDF5_INCLUDE_DIRS} ${FFTW3_INCLUDE_DIRS})
 target_link_libraries(PyFANS PRIVATE FANS::FANS)
 
 add_custom_command(

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -395,7 +395,8 @@ void Reader ::ReadMS(int hm)
         FANS_free(tmp);
     } else {
         /* XYZ case: the slab is already in correct order */
-        ms = tmp; // steal the buffer; no copy
+        FANS_free(ms); // dealloc mem
+        ms = tmp;      // steal the buffer; no copy
     }
 
     /*--------------------------------------------------------------------


### PR DESCRIPTION
- Fixes a mem-leak encountered during `Reader::ReadMS`
- Updates CMake files to support a wider range of systems. Depending on the system, the previous version would sometimes fail to compile.

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
